### PR TITLE
Update bucket policy for latest code

### DIFF
--- a/anti-virus-update.tf
+++ b/anti-virus-update.tf
@@ -50,6 +50,21 @@ data "aws_iam_policy_document" "main_update" {
 
     resources = ["arn:aws:s3:::${var.av_definition_s3_bucket}/${var.av_definition_s3_prefix}/*"]
   }
+
+  statement {
+    sid = "s3HeadObject"
+
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.av_definition_s3_bucket}",
+      "arn:aws:s3:::${var.av_definition_s3_bucket}/*",
+    ]
+  }
 }
 
 resource "aws_iam_role" "main_update" {


### PR DESCRIPTION
In https://github.com/upsidetravel/bucket-antivirus-function/pull/63 the required resource access changed and in https://github.com/upsidetravel/bucket-antivirus-function/pull/93 the README was updated to be more specific about that access.  This fixes our module to work with the new code.

I'll tag this as v1.1.0