### PR TITLE
Removing double declared argument

### DIFF
--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -170,8 +170,6 @@ resource "aws_lambda_function" "main_scan" {
 resource "aws_lambda_permission" "main_scan" {
   count = "${length(var.av_scan_buckets)}"
 
-  statement_id = "${local.name_scan}"
-
   action        = "lambda:InvokeFunction"
   function_name = "${aws_lambda_function.main_scan.function_name}"
 


### PR DESCRIPTION
Getting an issue when using in a project

```
  on .terraform/modules/s3_anti_virus/trussworks-terraform-aws-s3-anti-virus-e00d651/anti-virus-scan.tf line 183, in resource "aws_lambda_permission" "main_scan":
 183:   statement_id = "${local.name_scan}-${element(data.aws_s3_bucket.main_scan.*.id, count.index)}"

The argument "statement_id" was already set at
.terraform/modules/s3_anti_virus/trussworks-terraform-aws-s3-anti-virus-e00d651/anti-virus-scan.tf:173,3-15.
Each argument may be set only once.
```

Looking it seems to have just been overlooked