### PR TITLE
Allow s3:GetObjectVersion for scanning

### DIFF
--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -43,6 +43,7 @@ data "aws_iam_policy_document" "main_scan" {
     actions = [
       "s3:GetObject",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
       "s3:PutObjectTagging",
       "s3:PutObjectVersionTagging",
     ]


### PR DESCRIPTION
This missing action broke the anti-virus scanner. I discovered it while fixing https://github.com/upsidetravel/bucket-antivirus-function/pull/96.