### PR TITLE
Revising memory and timeout settings for flexibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:db021bd967924b23174fc735a7305c868d51011b
+      - image: trussworks/circleci-docker-primary:683f06a3c6b20ba8696a09632c1c26a532df5bf5
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ module "s3_anti_virus" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
 ## Providers
 
 | Name | Version |
@@ -80,7 +86,7 @@ module "s3_anti_virus" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | av\_definition\_s3\_bucket | Bucket containing antivirus database files. | `string` | n/a | yes |
 | av\_definition\_s3\_prefix | Prefix for antivirus database files. | `string` | `"clamav_defs"` | no |
 | av\_scan\_buckets | A list of S3 bucket names to scan for viruses. | `list(string)` | n/a | yes |
@@ -93,9 +99,11 @@ module "s3_anti_virus" {
 | lambda\_package | The name of the lambda package. Used for a directory tree and zip file. | `string` | `"anti-virus"` | no |
 | lambda\_s3\_bucket | The name of the S3 bucket used to store the Lambda builds. | `string` | n/a | yes |
 | lambda\_version | The version the Lambda function to deploy. | `string` | n/a | yes |
+| memory\_size | Lambda memory allocation, in MB | `string` | `20488888888` | no |
 | name\_scan | Name for resources associated with anti-virus scanning | `string` | `"s3-anti-virus-scan"` | no |
 | name\_update | Name for resources associated with anti-virus updating | `string` | `"s3-anti-virus-updates"` | no |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| timeout\_seconds | Lambda timeout, in seconds | `string` | `300` | no |
 
 ## Outputs
 

--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -170,8 +170,8 @@ resource "aws_lambda_function" "main_scan" {
   role          = aws_iam_role.main_scan.arn
   handler       = "scan.lambda_handler"
   runtime       = "python3.7"
-  memory_size   = "1024"
-  timeout       = "300"
+  memory_size   = var.memory_size
+  timeout       = var.timeout
 
   environment {
     variables = {

--- a/anti-virus-update.tf
+++ b/anti-virus-update.tf
@@ -129,8 +129,8 @@ resource "aws_lambda_function" "main_update" {
   role          = aws_iam_role.main_update.arn
   handler       = "update.lambda_handler"
   runtime       = "python3.7"
-  memory_size   = "1024"
-  timeout       = "300"
+  memory_size   = var.memory_size
+  timeout       = var.timeout_seconds
 
   environment {
     variables = {

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "lambda_package" {
   default     = "anti-virus"
 }
 
+variable "memory_size" {
+  description = "Lambda memory allocation, in MB"
+  type        = string
+  default     = 1536
+}
+
 variable "av_update_minutes" {
   default     = 180
   description = "How often to download updated Anti-Virus databases."
@@ -47,6 +53,12 @@ variable "tags" {
   description = "A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+}
+
+variable "timeout_seconds" {
+  description = "Lambda timeout, in seconds"
+  type        = string
+  default     = 300
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "lambda_package" {
 variable "memory_size" {
   description = "Lambda memory allocation, in MB"
   type        = string
-  default     = 1536
+  default     = 20488888888
 }
 
 variable "av_update_minutes" {


### PR DESCRIPTION
Yesterday, ClamAV started timing out on every run shortly after retrieving new virus definitions. I think the issue is that it is getting memory starved now; I noticed it's trying to use 1025MB of the 1024MB that was allocated to it, and bumping it up manually to 2048 got it to work, with a max memory usage of ~1300 MB. In order to get this working again, I'm making the memory and timeout values configurable at the module level, and bumping the default to 1.5GB.