### PR TITLE
Upgrade terraform13

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Creates the following resources for anti-virus scanning:
 
 ## Terraform Versions
 
-Terraform 0.12. Pin module version to `~> 2.0.0`. Submit pull-requests to `master` branch.
+Terraform 0.13. Pin module version to `~> 3.X`. Submit pull-requests to `master` branch.
+
+Terraform 0.12. Pin module version to `~> 2.X`. Submit pull-requests to `terraform012` branch.
 
 Terraform 0.11. Pin module version to `~> 1.1.1`. Submit pull-requests to `terraform011` branch.
 

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ module "s3_anti_virus" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12.0 |
-| aws | ~> 2.70 |
+| terraform | ~> 0.13.0 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = "~> 0.13.0"
 
   required_providers {
-    aws = "~> 2.70"
+    aws = "~> 3.0"
   }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Upgrade to terraform 13 since `circleci` is built with that version of TF
- Upgrade AWS provider to 3.0

## Checklist for Terraform changes

<!--
    - [x] a checked item
    - [ ] an unchecked item
-->

- [ ] Type `atlantis plan` as a Github comment to share your Terraform plan
- [ ] Get PR approval
- [ ] Type `atlantis apply`as a Github comment to apply and merge the plan

If the apply is successful, Atlantis will delete the branch and plan file.

---
<details><summary>Terraform plan</summary>

```terraform
Add Terraform plan here
```

</details>
