### PR TITLE
updating version restrains to take tf14 and remove tf11 in readme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
     steps:
     - checkout
     - restore_cache:
@@ -17,8 +17,7 @@ jobs:
         key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
         paths:
         - ~/.cache/pre-commit
-references:
-  circleci: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+
 version: 2.1
 workflows:
   validate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,12 +12,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.26.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.37.0
+    rev: v1.45.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@ Creates the following resources for anti-virus scanning:
 
 ## Terraform Versions
 
-Terraform 0.13. Pin module version to `~> 3.X`. Submit pull-requests to `master` branch.
+Terraform 0.13 and newer. Pin module version to `~> 3.X`. Submit pull-requests to `master` branch.
 
 Terraform 0.12. Pin module version to `~> 2.X`. Submit pull-requests to `terraform012` branch.
-
-Terraform 0.11. Pin module version to `~> 1.1.1`. Submit pull-requests to `terraform011` branch.
 
 ## Usage
 
@@ -77,14 +75,14 @@ module "s3_anti_virus" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13.0 |
-| aws | ~> 3.0 |
+| terraform | >= 0.13.0 |
+| aws | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
Pivotal ticket: https://www.pivotaltracker.com/story/show/176263153

- Update the circleci docker container image
- Update the terraform module version constraints to allow TF 14
- Update pre-commit hook versions
- Remove references to TF11
