### PR TITLE
Let the user pick the object key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ module "s3_anti_virus" {
   name_update = "s3-anti-virus-updates"
 
   lambda_s3_bucket = "lambda-builds-us-west-2"
-  lambda_version   = "2.0.0"
-  lambda_package   = "anti-virus"
+  lambda_package_key   = "lambda.zip"
 
   av_update_minutes = "180"
   av_scan_buckets   = ["bucket-name"]

--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -164,7 +164,7 @@ resource "aws_lambda_function" "main_scan" {
   description = "Scans s3 objects with clamav for viruses."
 
   s3_bucket = var.lambda_s3_bucket
-  s3_key    = "${var.lambda_package}/${var.lambda_version}/${var.lambda_package}.zip"
+  s3_key    = var.lambda_package_key
 
   function_name = var.name_scan
   role          = aws_iam_role.main_scan.arn

--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -164,7 +164,7 @@ resource "aws_lambda_function" "main_scan" {
   description = "Scans s3 objects with clamav for viruses."
 
   s3_bucket = var.lambda_s3_bucket
-  s3_key    = var.lambda_package_key
+  s3_key    = local.lambda_package_key
 
   function_name = var.name_scan
   role          = aws_iam_role.main_scan.arn

--- a/anti-virus-update.tf
+++ b/anti-virus-update.tf
@@ -123,7 +123,7 @@ resource "aws_lambda_function" "main_update" {
   description = "Updates clamav definitions stored in s3."
 
   s3_bucket = var.lambda_s3_bucket
-  s3_key    = "${var.lambda_package}/${var.lambda_version}/${var.lambda_package}.zip"
+  s3_key    = var.lambda_package_key
 
   function_name = var.name_update
   role          = aws_iam_role.main_update.arn

--- a/anti-virus-update.tf
+++ b/anti-virus-update.tf
@@ -123,7 +123,7 @@ resource "aws_lambda_function" "main_update" {
   description = "Updates clamav definitions stored in s3."
 
   s3_bucket = var.lambda_s3_bucket
-  s3_key    = var.lambda_package_key
+  s3_key    = local.lambda_package_key
 
   function_name = var.name_update
   role          = aws_iam_role.main_update.arn

--- a/main.tf
+++ b/main.tf
@@ -6,3 +6,7 @@ data "aws_caller_identity" "current" {}
 
 # The AWS partition (commercial or govcloud)
 data "aws_partition" "current" {}
+
+locals {
+  lambda_package_key = var.lambda_package_key != null ? var.lambda_package_key : "${var.lambda_package}/${var.lambda_version}/${var.lambda_package}.zip"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -21,10 +21,20 @@ variable "lambda_s3_bucket" {
   type        = string
 }
 
-variable "lambda_package_key" {
-  description = "The object key for the lambda distribution. Defaults to lambda.zip since this is build by default upstream."
+variable "lambda_version" {
+  description = "The version the Lambda function to deploy."
+}
+
+variable "lambda_package" {
+  description = "The name of the lambda package. Used for a directory tree and zip file."
   type        = string
-  default     = "lambda.zip"
+  default     = "anti-virus"
+}
+
+variable "lambda_package_key" {
+  description = "The object key for the lambda distribution. If given, the value is used as the key in lieu of the value constructed using `lambda_package` and `lambda_version`."
+  type        = string
+  default     = null
 }
 
 variable "memory_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -21,15 +21,10 @@ variable "lambda_s3_bucket" {
   type        = string
 }
 
-variable "lambda_version" {
-  description = "The version the Lambda function to deploy."
+variable "lambda_package_key" {
+  description = "The object key for the lambda distribution. Defaults to lambda.zip since this is build by default upstream."
   type        = string
-}
-
-variable "lambda_package" {
-  description = "The name of the lambda package. Used for a directory tree and zip file."
-  type        = string
-  default     = "anti-virus"
+  default     = "lambda.zip"
 }
 
 variable "memory_size" {


### PR DESCRIPTION
This allows more flexibility in how the user chooses to arrange versions
and builds in S3. It also changes the default archive to lambda.zip
since this is the upstream default.