### PR TITLE
Add optional permissions_boundary to attach to iam roles.

### DIFF
--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -105,9 +105,10 @@ data "aws_iam_policy_document" "main_scan" {
 }
 
 resource "aws_iam_role" "main_scan" {
-  name               = "lambda-${var.name_scan}"
-  assume_role_policy = data.aws_iam_policy_document.assume_role_scan.json
-  tags               = var.tags
+  name                 = "lambda-${var.name_scan}"
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_scan.json
+  permissions_boundary = var.permissions_boundary
+  tags                 = var.tags
 }
 
 resource "aws_iam_role_policy" "main_scan" {

--- a/anti-virus-update.tf
+++ b/anti-virus-update.tf
@@ -68,9 +68,10 @@ data "aws_iam_policy_document" "main_update" {
 }
 
 resource "aws_iam_role" "main_update" {
-  name               = "lambda-${var.name_update}"
-  assume_role_policy = data.aws_iam_policy_document.assume_role_update.json
-  tags               = var.tags
+  name                 = "lambda-${var.name_update}"
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_update.json
+  permissions_boundary = var.permissions_boundary
+  tags                 = var.tags
 }
 
 resource "aws_iam_role_policy" "main_update" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,11 @@ variable "av_scan_buckets" {
   type        = list(string)
 }
 
+variable "permissions_boundary" {
+  description = "ARN of the boundary policy to attach to roles."
+  default     = null
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources."
   type        = map(string)


### PR DESCRIPTION
In some organizations, attachment of boundaries is not optional. This allows users to pass in a boundary, but otherwise behaves fine without it.