### PR TITLE
Added a little bit more flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,10 @@ module "s3_anti_virus" {
 
 ## TODO
 
-[ ] Add directory with examples
-[ ] Add lambda function build to the module using local-exec.
-[ ] ^ Don't forget to check the installed docker on the local machine
-[ ] Fix permanent triggers and false positives with source_account `(known after apply) # forces replacement
+* [ ] Add directory with examples
+* [ ] Add lambda function build to the module using local-exec.
+* [ ] ^ Don't forget to check the installed docker on the local machine
+* [ ] Fix permanent triggers and false positives with source_account `(known after apply) # forces replacement
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Creates an AWS Lambda function to do anti-virus scanning of objects in AWS S3
 using [bucket-antivirus-function](https://github.com/upsidetravel/bucket-antivirus-function)
 
-While waiting for updates on that repo you will need to use a special resitory:
+While waiting for updates on that repo you will need to use a special repository:
 
 ```sh
 git clone git@github.com:upsidetravel/bucket-antivirus-function.git
@@ -167,7 +167,7 @@ module "s3_anti_virus" {
 * [ ] Add directory with examples
 * [ ] Add lambda function build to the module using local-exec.
 * [ ] ^ Don't forget to check the installed docker on the local machine
-* [ ] Fix permanent triggers and false positives with source_account `(known after apply) # forces replacement
+* [ ] Fix permanent triggers and false positives with source_account `(known after apply) # forces replacement`
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@ or use the [s3_bucket_object](https://registry.terraform.io/providers/hashicorp/
 
 ```hcl
 ...
+
 resource "aws_s3_bucket_object" "function_zip" {
   ## https://github.com/upsidetravel/bucket-antivirus-function
+  bucket = module.s3_bucket_dependencies.bucket_id
   key    = "lambda.zip"
-  bucket = module.s3_dependencies.bucket_id
   source = "./bucket-antivirus-function/build/lambda.zip"
   etag   = filemd5("./bucket-antivirus-function/build/lambda.zip")
   ...
 }
+
 ...
 ```
 
@@ -115,8 +117,8 @@ resource "null_resource" "build_function" {
 resource "aws_s3_bucket_object" "function_zip" {
   ## https://github.com/upsidetravel/bucket-antivirus-function
   ## Remote
+  bucket = module.s3_bucket_dependencies.bucket_id
   key    = local.s3_object_clamav_func
-  bucket = module.s3_dependencies.bucket_id
 
   ## Local
   source = "./${local.dir_build}/lambda.zip"
@@ -138,11 +140,11 @@ module "s3_anti_virus" {
   name_update = "${module.naming.id}-updates"
 
   ## https://github.com/upsidetravel/bucket-antivirus-function
-  lambda_s3_bucket     = module.s3_dependencies.bucket_id
+  lambda_s3_bucket     = module.s3_bucket_dependencies.bucket_id
   lambda_s3_object_key = aws_s3_bucket_object.function_zip.key
 
   av_update_schedule_expression = "rate(6 hours)"
-  av_definition_s3_bucket       = module.s3_dependencies.bucket_id
+  av_definition_s3_bucket       = module.s3_bucket_dependencies.bucket_id
   av_definition_s3_prefix       = "ClamAV_Virus_Database"
 
   av_scan_buckets = [
@@ -151,7 +153,7 @@ module "s3_anti_virus" {
   ]
 
   depends_on = [
-    module.s3_dependencies,
+    module.s3_bucket_dependencies,
     aws_s3_bucket_object.function_zip
   ]
 
@@ -219,7 +221,7 @@ No modules.
 | <a name="input_av_definition_s3_bucket"></a> [av\_definition\_s3\_bucket](#input\_av\_definition\_s3\_bucket) | Bucket containing antivirus database files. | `string` | n/a | yes |
 | <a name="input_av_definition_s3_prefix"></a> [av\_definition\_s3\_prefix](#input\_av\_definition\_s3\_prefix) | Prefix for antivirus database files. | `string` | `"clamav_defs"` | no |
 | <a name="input_av_delete_infected_files"></a> [av\_delete\_infected\_files](#input\_av\_delete\_infected\_files) | Set it True in order to delete infected values. | `bool` | `false` | no |
-| <a name="input_av_process_original_version_only"></a> [av\_process\_original\_version\_only](#input\_av\_process\_original\_version\_only) | Controls that only original version of an S3 key is processed (if bucket versioning is enabled) | `bool` | `true` | no |
+| <a name="input_av_process_original_version_only"></a> [av\_process\_original\_version\_only](#input\_av\_process\_original\_version\_only) | Controls that only original version of an S3 key is processed (if bucket versioning is enabled) | `bool` | `false` | no |
 | <a name="input_av_scan_buckets"></a> [av\_scan\_buckets](#input\_av\_scan\_buckets) | A list of S3 bucket names to scan for viruses. | `list(string)` | n/a | yes |
 | <a name="input_av_scan_start_metadata"></a> [av\_scan\_start\_metadata](#input\_av\_scan\_start\_metadata) | The tag/metadata indicating the start of the scan | `string` | `"av-scan-start"` | no |
 | <a name="input_av_scan_start_sns_arn"></a> [av\_scan\_start\_sns\_arn](#input\_av\_scan\_start\_sns\_arn) | SNS topic ARN to publish notification about start of scan (optional). | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -4,23 +4,33 @@
 Creates an AWS Lambda function to do anti-virus scanning of objects in AWS S3
 using [bucket-antivirus-function](https://github.com/upsidetravel/bucket-antivirus-function)
 
-While waiting for updates on that repo you will need to use a special fork and branch:
+While waiting for updates on that repo you will need to use a special resitory:
 
 ```sh
 git clone git@github.com:upsidetravel/bucket-antivirus-function.git
 cd bucket-antivirus-function
-git checkout v2.0.0
 ```
 
-With that repo checked out you must run the `make` command and then copy the resulting zip file
-to AWS S3 with:
+With that repo checked out you must run the `make all` command and then copy the resulting zip file to AWS S3 with:
 
 ```sh
-VERSION=2.0.0
-aws s3 cp bucket-antivirus-function/build/lambda.zip "s3://lambda-builds-us-west-2/anti-virus/${VERSION}/anti-virus.zip"
+aws s3 cp bucket-antivirus-function/build/lambda.zip "s3://your-s3-bucket-for-lambda-dependencies/lambda.zip"
 ```
 
-NOTE: It is a good idea to make `VERSION` match the git tag you are deploying.
+or use the [s3_bucket_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) resource in your Terraform code
+
+```hcl
+...
+resource "aws_s3_bucket_object" "function_zip" {
+  ## https://github.com/upsidetravel/bucket-antivirus-function
+  key    = "lambda.zip"
+  bucket = module.s3_dependencies.bucket_id
+  source = "./bucket-antivirus-function/build/lambda.zip"
+  etag   = filemd5("./bucket-antivirus-function/build/lambda.zip")
+  ...
+}
+...
+```
 
 Creates the following resources for anti-virus updates:
 
@@ -50,9 +60,8 @@ module "s3_anti_virus" {
   name_scan   = "s3-anti-virus-scan"
   name_update = "s3-anti-virus-updates"
 
-  lambda_s3_bucket = "lambda-builds-us-west-2"
-  lambda_version   = "2.0.0"
-  lambda_package   = "anti-virus"
+  lambda_s3_bucket            = "lambda-builds-us-west-2"
+  lambda_s3_object_key        = "lambda.zip"
 
   av_update_minutes = "180"
   av_scan_buckets   = ["bucket-name"]
@@ -67,6 +76,96 @@ module "s3_anti_virus" {
   }
 }
 ```
+
+## Example
+
+```hcl
+...
+
+locals {
+  dir_source_code_function = "temp/bucket-antivirus-function"
+  dir_build                = "temp/build"
+  s3_object_clamav_func    = "Lambda_Function/lambda.zip"
+}
+
+resource "null_resource" "build_function" {
+  triggers = {
+    md5file = try(filemd5("./${local.dir_build}/lambda.zip"), timestamp())
+  }
+
+  ## Docker is required on your local machine!
+  ## https://www.docker.com/get-started
+  ##
+  provisioner "local-exec" {
+    interpreter = ["docker"]
+    command     = "-v"
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      mkdir -p ./${local.dir_source_code_function} ./${local.dir_build} &&
+      git clone git@github.com:upsidetravel/bucket-antivirus-function.git ./${local.dir_source_code_function} &&
+      docker build -t bucket-antivirus-function:latest $(pwd)/${local.dir_source_code_function} &&
+      docker run -v $(pwd)/${local.dir_build}:/opt/mount --rm --entrypoint cp bucket-antivirus-function:latest /opt/app/build/lambda.zip /opt/mount/lambda.zip &&
+      rm -rf ./${local.dir_source_code_function}
+    EOT
+  }
+}
+
+resource "aws_s3_bucket_object" "function_zip" {
+  ## https://github.com/upsidetravel/bucket-antivirus-function
+  ## Remote
+  key    = local.s3_object_clamav_func
+  bucket = module.s3_dependencies.bucket_id
+
+  ## Local
+  source = "./${local.dir_build}/lambda.zip"
+  etag   = try(filemd5("./${local.dir_build}/lambda.zip"), null)
+  tags   = module.naming.tags
+
+  depends_on = [
+    null_resource.build_function
+  ]
+}
+
+module "s3_anti_virus" {
+  ## https://github.com/trussworks/terraform-aws-s3-anti-virus
+  ## https://registry.terraform.io/modules/trussworks/s3-anti-virus/aws/latest
+  source  = "trussworks/s3-anti-virus/aws"
+  version = "~> x.x.x"
+
+  name_scan   = "${module.naming.id}-scan"
+  name_update = "${module.naming.id}-updates"
+
+  ## https://github.com/upsidetravel/bucket-antivirus-function
+  lambda_s3_bucket     = module.s3_dependencies.bucket_id
+  lambda_s3_object_key = aws_s3_bucket_object.function_zip.key
+
+  av_update_schedule_expression = "rate(6 hours)"
+  av_definition_s3_bucket       = module.s3_dependencies.bucket_id
+  av_definition_s3_prefix       = "ClamAV_Virus_Database"
+
+  av_scan_buckets = [
+    module.s3_bucket_test_1.bucket_id,
+    module.s3_bucket_test_2.bucket_id
+  ]
+
+  depends_on = [
+    module.s3_dependencies,
+    aws_s3_bucket_object.function_zip
+  ]
+
+  tags = module.naming.tags
+}
+...
+```
+
+## TODO
+
+[ ] Add directory with examples
+[ ] Add lambda function build to the module using local-exec.
+[ ] ^ Don't forget to check the installed docker on the local machine
+[ ] Fix permanent triggers and false positives with source_account `(known after apply) # forces replacement
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -116,25 +215,41 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_av_definition_path"></a> [av\_definition\_path](#input\_av\_definition\_path) | Path containing files at runtime | `string` | `"/tmp/clamav_defs"` | no |
 | <a name="input_av_definition_s3_bucket"></a> [av\_definition\_s3\_bucket](#input\_av\_definition\_s3\_bucket) | Bucket containing antivirus database files. | `string` | n/a | yes |
 | <a name="input_av_definition_s3_prefix"></a> [av\_definition\_s3\_prefix](#input\_av\_definition\_s3\_prefix) | Prefix for antivirus database files. | `string` | `"clamav_defs"` | no |
-| <a name="input_av_delete_infected_files"></a> [av\_delete\_infected\_files](#input\_av\_delete\_infected\_files) | Set it True in order to delete infected values. | `string` | `"False"` | no |
+| <a name="input_av_delete_infected_files"></a> [av\_delete\_infected\_files](#input\_av\_delete\_infected\_files) | Set it True in order to delete infected values. | `bool` | `false` | no |
+| <a name="input_av_process_original_version_only"></a> [av\_process\_original\_version\_only](#input\_av\_process\_original\_version\_only) | Controls that only original version of an S3 key is processed (if bucket versioning is enabled) | `bool` | `true` | no |
 | <a name="input_av_scan_buckets"></a> [av\_scan\_buckets](#input\_av\_scan\_buckets) | A list of S3 bucket names to scan for viruses. | `list(string)` | n/a | yes |
-| <a name="input_av_scan_start_sns_arn"></a> [av\_scan\_start\_sns\_arn](#input\_av\_scan\_start\_sns\_arn) | SNS topic ARN to publish notification about start of scan (optional). | `string` | `""` | no |
-| <a name="input_av_status_sns_arn"></a> [av\_status\_sns\_arn](#input\_av\_status\_sns\_arn) | SNS topic ARN to publish scan results (optional). | `string` | `""` | no |
-| <a name="input_av_status_sns_publish_clean"></a> [av\_status\_sns\_publish\_clean](#input\_av\_status\_sns\_publish\_clean) | Publish AV\_STATUS\_CLEAN results to AV\_STATUS\_SNS\_ARN. | `string` | `"True"` | no |
-| <a name="input_av_status_sns_publish_infected"></a> [av\_status\_sns\_publish\_infected](#input\_av\_status\_sns\_publish\_infected) | Publish AV\_STATUS\_INFECTED results to AV\_STATUS\_SNS\_ARN. | `string` | `"True"` | no |
-| <a name="input_av_update_minutes"></a> [av\_update\_minutes](#input\_av\_update\_minutes) | How often to download updated Anti-Virus databases. | `string` | `180` | no |
-| <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | Number of days to keep logs in AWS CloudWatch. | `string` | `90` | no |
-| <a name="input_lambda_package"></a> [lambda\_package](#input\_lambda\_package) | The name of the lambda package. Used for a directory tree and zip file. | `string` | `"anti-virus"` | no |
+| <a name="input_av_scan_start_metadata"></a> [av\_scan\_start\_metadata](#input\_av\_scan\_start\_metadata) | The tag/metadata indicating the start of the scan | `string` | `"av-scan-start"` | no |
+| <a name="input_av_scan_start_sns_arn"></a> [av\_scan\_start\_sns\_arn](#input\_av\_scan\_start\_sns\_arn) | SNS topic ARN to publish notification about start of scan (optional). | `string` | `null` | no |
+| <a name="input_av_signature_metadata"></a> [av\_signature\_metadata](#input\_av\_signature\_metadata) | The tag/metadata name representing file's AV type | `string` | `"av-signature"` | no |
+| <a name="input_av_status_clean"></a> [av\_status\_clean](#input\_av\_status\_clean) | The value assigned to clean items inside of tags/metadata | `string` | `"CLEAN"` | no |
+| <a name="input_av_status_infected"></a> [av\_status\_infected](#input\_av\_status\_infected) | The value assigned to clean items inside of tags/metadata | `string` | `"INFECTED"` | no |
+| <a name="input_av_status_metadata"></a> [av\_status\_metadata](#input\_av\_status\_metadata) | The tag/metadata name representing file's AV status | `string` | `"av-status"` | no |
+| <a name="input_av_status_sns_arn"></a> [av\_status\_sns\_arn](#input\_av\_status\_sns\_arn) | SNS topic ARN to publish scan results (optional). | `string` | `null` | no |
+| <a name="input_av_status_sns_publish_clean"></a> [av\_status\_sns\_publish\_clean](#input\_av\_status\_sns\_publish\_clean) | Publish AV\_STATUS\_CLEAN results to AV\_STATUS\_SNS\_ARN. | `bool` | `true` | no |
+| <a name="input_av_status_sns_publish_infected"></a> [av\_status\_sns\_publish\_infected](#input\_av\_status\_sns\_publish\_infected) | Publish AV\_STATUS\_INFECTED results to AV\_STATUS\_SNS\_ARN. | `bool` | `true` | no |
+| <a name="input_av_timestamp_metadata"></a> [av\_timestamp\_metadata](#input\_av\_timestamp\_metadata) | The tag/metadata name representing file's scan time | `string` | `"av-timestamp"` | no |
+| <a name="input_av_update_minutes"></a> [av\_update\_minutes](#input\_av\_update\_minutes) | How often to download updated Anti-Virus databases. | `number` | `null` | no |
+| <a name="input_av_update_schedule_expression"></a> [av\_update\_schedule\_expression](#input\_av\_update\_schedule\_expression) | A new, more flexible option for the scheduler. Not working if `av_update_minutes` variable is set. The scheduling expression how often to download updated Anti-Virus databases. [For example, cron(0 20 * * ? *) or rate(180 minutes)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html) | `string` | `"rate(180 minutes)"` | no |
+| <a name="input_clamavlib_path"></a> [clamavlib\_path](#input\_clamavlib\_path) | Path to ClamAV library files | `string` | `"./bin"` | no |
+| <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | Number of days to keep logs in AWS CloudWatch. | `number` | `90` | no |
+| <a name="input_datadog_api_key"></a> [datadog\_api\_key](#input\_datadog\_api\_key) | API Key for pushing metrics to DataDog (optional) | `string` | `null` | no |
+| <a name="input_event_source"></a> [event\_source](#input\_event\_source) | The source of antivirus scan event "S3" or "SNS" (optional) | `string` | `"S3"` | no |
+| <a name="input_lambda_package"></a> [lambda\_package](#input\_lambda\_package) | Deprecated. The name of the lambda package. Used for a directory tree and zip file. | `string` | `"anti-virus"` | no |
+| <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | Identifier of the function's runtime. | `string` | `"python3.7"` | no |
 | <a name="input_lambda_s3_bucket"></a> [lambda\_s3\_bucket](#input\_lambda\_s3\_bucket) | The name of the S3 bucket used to store the Lambda builds. | `string` | n/a | yes |
-| <a name="input_lambda_version"></a> [lambda\_version](#input\_lambda\_version) | The version the Lambda function to deploy. | `string` | n/a | yes |
-| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Lambda memory allocation, in MB | `string` | `2048` | no |
+| <a name="input_lambda_s3_object_key"></a> [lambda\_s3\_object\_key](#input\_lambda\_s3\_object\_key) | The object key for the lambda distribution. If given, the value is used as the key in lieu of the value constructed using `lambda_package` and `lambda_version`. | `string` | `null` | no |
+| <a name="input_lambda_version"></a> [lambda\_version](#input\_lambda\_version) | Deprecated. The version the Lambda function to deploy. | `string` | `"2.0.0"` | no |
+| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Lambda memory allocation, in MB | `number` | `2048` | no |
 | <a name="input_name_scan"></a> [name\_scan](#input\_name\_scan) | Name for resources associated with anti-virus scanning | `string` | `"s3-anti-virus-scan"` | no |
 | <a name="input_name_update"></a> [name\_update](#input\_name\_update) | Name for resources associated with anti-virus updating | `string` | `"s3-anti-virus-updates"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | ARN of the boundary policy to attach to IAM roles. | `string` | `null` | no |
+| <a name="input_s3_endpoint"></a> [s3\_endpoint](#input\_s3\_endpoint) | The Endpoint to use when interacting wth S3 | `string` | `null` | no |
+| <a name="input_sns_endpoint"></a> [sns\_endpoint](#input\_sns\_endpoint) | The Endpoint to use when interacting wth SNS | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
-| <a name="input_timeout_seconds"></a> [timeout\_seconds](#input\_timeout\_seconds) | Lambda timeout, in seconds | `string` | `300` | no |
+| <a name="input_timeout_seconds"></a> [timeout\_seconds](#input\_timeout\_seconds) | Lambda timeout, in seconds | `number` | `300` | no |
 
 ## Outputs
 

--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -41,14 +41,13 @@ data "aws_iam_policy_document" "main_scan" {
     effect = "Allow"
 
     actions = [
-      "s3:GetObject",
-      "s3:GetObjectTagging",
-      "s3:GetObjectVersion",
-      "s3:PutObjectTagging",
-      "s3:PutObjectVersionTagging",
+      "s3:*",
     ]
 
-    resources = formatlist("%s/*", data.aws_s3_bucket.main_scan.*.arn)
+    resources = concat(
+      tolist(data.aws_s3_bucket.main_scan.*.arn),
+      formatlist("%s/*", data.aws_s3_bucket.main_scan.*.arn)
+    )
   }
 
   statement {

--- a/main.tf
+++ b/main.tf
@@ -6,3 +6,11 @@ data "aws_caller_identity" "current" {}
 
 # The AWS partition (commercial or govcloud)
 data "aws_partition" "current" {}
+
+locals {
+  aws_account_id         = data.aws_caller_identity.current.account_id
+  aws_partition          = data.aws_partition.current.partition
+  aws_region_name        = data.aws_region.current.name
+  cw_schedule_expression = var.av_update_minutes != null ? "rate(${var.av_update_minutes} minutes)" : var.av_update_schedule_expression
+  lambda_s3_object_key   = var.lambda_s3_object_key != null ? var.lambda_s3_object_key : "${var.lambda_package}/${var.lambda_version}/${var.lambda_package}.zip"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -134,7 +134,7 @@ variable "av_delete_infected_files" {
 variable "av_process_original_version_only" {
   description = "Controls that only original version of an S3 key is processed (if bucket versioning is enabled)"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "av_scan_start_metadata" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "name_update" {
 variable "cloudwatch_logs_retention_days" {
   default     = 90
   description = "Number of days to keep logs in AWS CloudWatch."
-  type        = string
+  type        = number
 }
 
 variable "lambda_s3_bucket" {
@@ -22,25 +22,44 @@ variable "lambda_s3_bucket" {
 }
 
 variable "lambda_version" {
-  description = "The version the Lambda function to deploy."
+  description = "Deprecated. The version the Lambda function to deploy."
   type        = string
+  default     = "2.0.0"
 }
 
 variable "lambda_package" {
-  description = "The name of the lambda package. Used for a directory tree and zip file."
+  description = "Deprecated. The name of the lambda package. Used for a directory tree and zip file."
   type        = string
   default     = "anti-virus"
 }
 
+variable "lambda_s3_object_key" {
+  description = "The object key for the lambda distribution. If given, the value is used as the key in lieu of the value constructed using `lambda_package` and `lambda_version`."
+  type        = string
+  default     = null
+}
+
+variable "lambda_runtime" {
+  type        = string
+  default     = "python3.7"
+  description = "Identifier of the function's runtime."
+}
+
 variable "memory_size" {
   description = "Lambda memory allocation, in MB"
-  type        = string
+  type        = number
   default     = 2048
 }
 
 variable "av_update_minutes" {
-  default     = 180
+  default     = null
   description = "How often to download updated Anti-Virus databases."
+  type        = number
+}
+
+variable "av_update_schedule_expression" {
+  default     = "rate(180 minutes)"
+  description = "A new, more flexible option for the scheduler. Not working if `av_update_minutes` variable is set. The scheduling expression how often to download updated Anti-Virus databases. [For example, cron(0 20 * * ? *) or rate(180 minutes)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html)"
   type        = string
 }
 
@@ -63,12 +82,13 @@ variable "tags" {
 
 variable "timeout_seconds" {
   description = "Lambda timeout, in seconds"
-  type        = string
+  type        = number
   default     = 300
 }
 
 #
 # The variables below correspond to https://github.com/upsidetravel/bucket-antivirus-function/tree/master#configuration
+# https://github.com/upsidetravel/bucket-antivirus-function/blob/master/common.py
 #
 variable "av_definition_s3_bucket" {
   description = "Bucket containing antivirus database files."
@@ -84,29 +104,107 @@ variable "av_definition_s3_prefix" {
 variable "av_scan_start_sns_arn" {
   description = "SNS topic ARN to publish notification about start of scan (optional)."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "av_status_sns_arn" {
   description = "SNS topic ARN to publish scan results (optional)."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "av_status_sns_publish_clean" {
   description = "Publish AV_STATUS_CLEAN results to AV_STATUS_SNS_ARN."
-  type        = string
-  default     = "True"
+  type        = bool
+  default     = true
 }
 
 variable "av_status_sns_publish_infected" {
   description = "Publish AV_STATUS_INFECTED results to AV_STATUS_SNS_ARN."
-  type        = string
-  default     = "True"
+  type        = bool
+  default     = true
 }
 
 variable "av_delete_infected_files" {
   description = "Set it True in order to delete infected values."
+  type        = bool
+  default     = false
+}
+
+variable "av_process_original_version_only" {
+  description = "Controls that only original version of an S3 key is processed (if bucket versioning is enabled)"
+  type        = bool
+  default     = true
+}
+
+variable "av_scan_start_metadata" {
+  description = "The tag/metadata indicating the start of the scan"
   type        = string
-  default     = "False"
+  default     = "av-scan-start"
+}
+
+variable "av_signature_metadata" {
+  description = "The tag/metadata name representing file's AV type"
+  type        = string
+  default     = "av-signature"
+}
+
+variable "av_status_clean" {
+  description = "The value assigned to clean items inside of tags/metadata"
+  type        = string
+  default     = "CLEAN"
+}
+
+variable "av_status_infected" {
+  description = "The value assigned to clean items inside of tags/metadata"
+  type        = string
+  default     = "INFECTED"
+}
+
+variable "av_status_metadata" {
+  description = "The tag/metadata name representing file's AV status"
+  type        = string
+  default     = "av-status"
+}
+
+variable "av_timestamp_metadata" {
+  description = "The tag/metadata name representing file's scan time"
+  type        = string
+  default     = "av-timestamp"
+}
+
+variable "event_source" {
+  description = "The source of antivirus scan event \"S3\" or \"SNS\" (optional)"
+  type        = string
+  default     = "S3"
+}
+
+variable "s3_endpoint" {
+  description = "The Endpoint to use when interacting wth S3"
+  type        = string
+  default     = null
+}
+
+variable "sns_endpoint" {
+  description = "The Endpoint to use when interacting wth SNS"
+  type        = string
+  default     = null
+}
+
+variable "datadog_api_key" {
+  description = "API Key for pushing metrics to DataDog (optional)"
+  type        = string
+  default     = null
+}
+
+variable "av_definition_path" {
+  description = "Path containing files at runtime"
+  type        = string
+  default     = "/tmp/clamav_defs"
+}
+
+variable "clamavlib_path" {
+  description = "Path to ClamAV library files"
+  type        = string
+  default     = "./bin"
 }


### PR DESCRIPTION
1. Updated documentation. Added example with automatic archive build. Added TODO.
2. Fixed name of s3 object key. Saved backward compatibility.
3. Fixed variable types.
4. Added all variables for Lambda Function. New version of the code has many more fixes than in 2.0.0 (https://github.com/upsidetravel/bucket-antivirus-function/compare/v2.0.0...master)
5. Added new scheduler record format, as in [cloudwatch_event_rule#schedule_expression](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule#schedule_expression)
5.1. https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
5.2.  Not working if `av_update_minutes` variable is set!
6. SCAN function. Added all permissions for deleting files and getting all versions of objects and tags.


@theherk Please check this PR. I added the S3 object key a little bit differently [than you have](https://github.com/trussworks/terraform-aws-s3-anti-virus/pull/24).
