### PR TITLE
NT: enable cloudwatch log group encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ No modules.
 | <a name="input_av_status_sns_publish_clean"></a> [av\_status\_sns\_publish\_clean](#input\_av\_status\_sns\_publish\_clean) | Publish AV\_STATUS\_CLEAN results to AV\_STATUS\_SNS\_ARN. | `string` | `"True"` | no |
 | <a name="input_av_status_sns_publish_infected"></a> [av\_status\_sns\_publish\_infected](#input\_av\_status\_sns\_publish\_infected) | Publish AV\_STATUS\_INFECTED results to AV\_STATUS\_SNS\_ARN. | `string` | `"True"` | no |
 | <a name="input_av_update_minutes"></a> [av\_update\_minutes](#input\_av\_update\_minutes) | How often to download updated Anti-Virus databases. | `string` | `180` | no |
+| <a name="input_cloudwatch_kms_arn"></a> [cloudwatch\_kms\_arn](#input\_cloudwatch\_kms\_arn) | The arn of the kms key used for encrypting the cloudwatch log groups created by this module. | `string` | `""` | no |
 | <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | Number of days to keep logs in AWS CloudWatch. | `string` | `90` | no |
 | <a name="input_lambda_package"></a> [lambda\_package](#input\_lambda\_package) | The name of the lambda package. Used for a directory tree and zip file. | `string` | `"anti-virus"` | no |
 | <a name="input_lambda_package_key"></a> [lambda\_package\_key](#input\_lambda\_package\_key) | The object key for the lambda distribution. If given, the value is used as the key in lieu of the value constructed using `lambda_package` and `lambda_version`. | `string` | `null` | no |

--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -148,6 +148,7 @@ resource "aws_cloudwatch_log_group" "main_scan" {
   # This name must match the lambda function name and should not be changed
   name              = "/aws/lambda/${var.name_scan}"
   retention_in_days = var.cloudwatch_logs_retention_days
+  kms_key_id        = var.cloudwatch_kms_arn
 
   tags = merge(
     {

--- a/anti-virus-update.tf
+++ b/anti-virus-update.tf
@@ -105,6 +105,7 @@ resource "aws_cloudwatch_log_group" "main_update" {
   # This name must match the lambda function name and should not be changed
   name              = "/aws/lambda/${var.name_update}"
   retention_in_days = var.cloudwatch_logs_retention_days
+  kms_key_id        = var.cloudwatch_kms_arn
 
   tags = merge(
     {

--- a/variables.tf
+++ b/variables.tf
@@ -115,3 +115,9 @@ variable "av_delete_infected_files" {
   type        = string
   default     = "False"
 }
+
+variable "cloudwatch_kms_arn" {
+  description = "The arn of the kms key used for encrypting the cloudwatch log groups created by this module."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Enables the ability to optionally encrypt cloudwatch log groups created by this module. 