### PR TITLE
Add configurable lambda ephemeral storage size

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ No modules.
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | ARN of the boundary policy to attach to IAM roles. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | <a name="input_timeout_seconds"></a> [timeout\_seconds](#input\_timeout\_seconds) | Lambda timeout, in seconds | `string` | `300` | no |
+| <a name="ephemeral_storage_size"></a> [ephemeral\_storage\_size](#ephemeral\_storage\_size) | Lambda ephemeral storage size, in MB | `number` | 512 | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ module "s3_anti_virus" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
 
 ## Modules
 

--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -189,6 +189,10 @@ resource "aws_lambda_function" "main_scan" {
     }
   }
 
+  ephemeral_storage {
+    size = var.ephemeral_storage_size # Min 512 MB and the Max 10240 MB
+  }
+
   tags = merge(
     {
       "Name" = var.name_scan

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,12 @@ variable "lambda_package_key" {
   default     = null
 }
 
+variable "ephemeral_storage_size" {
+  description = "The size of the Lambda function Ephemeral storage(/tmp) represented in MB. The minimum supported ephemeral_storage value defaults to 512MB and the maximum supported value is 10240MB."
+  type        = number
+  default     = 512
+}
+
 variable "memory_size" {
   description = "Lambda memory allocation, in MB"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 3.0"
+    aws = ">= 4.9.0"
   }
 }


### PR DESCRIPTION
Adds support for configuring lambda storage size. Useful if scanning for large files is required. https://aws.amazon.com/blogs/aws/aws-lambda-now-supports-up-to-10-gb-ephemeral-storage