### PR TITLE
[MB-13104] Documentation updates to reflect new anti-virus source

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-json
@@ -11,12 +11,12 @@ repos:
           - --autofix
       - id: trailing-whitespace
 
-  - repo: git://github.com/igorshubovych/markdownlint-cli
+  - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.28.1
     hooks:
       - id: markdownlint
 
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.50.0
     hooks:
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 # terraform-aws-s3-anti-virus
 
 Creates an AWS Lambda function to do anti-virus scanning of objects in AWS S3
-using [bucket-antivirus-function](https://github.com/upsidetravel/bucket-antivirus-function)
+using [bucket-antivirus-function](https://github.com/trussworks/bucket-antivirus-function)
 
-While waiting for updates on that repo you will need to use a special fork and branch:
+The source repository hasn't been updated in a long time, so we've forked the repo to our account and made changes.
 
 ```sh
-git clone git@github.com:upsidetravel/bucket-antivirus-function.git
+git clone git@github.com:trussworks/bucket-antivirus-function.git
 cd bucket-antivirus-function
-git checkout v2.0.0
+git checkout v2.2.0
 ```
 
 With that repo checked out you must run the `make` command and then copy the resulting zip file
 to AWS S3 with:
 
 ```sh
-VERSION=2.0.0
+VERSION=2.2.0
 aws s3 cp bucket-antivirus-function/build/lambda.zip "s3://lambda-builds-us-west-2/anti-virus/${VERSION}/anti-virus.zip"
 ```
 

--- a/variables.tf
+++ b/variables.tf
@@ -72,9 +72,6 @@ variable "timeout_seconds" {
   default     = 300
 }
 
-#
-# The variables below correspond to https://github.com/upsidetravel/bucket-antivirus-function/tree/master#configuration
-#
 variable "av_definition_s3_bucket" {
   description = "Bucket containing antivirus database files."
   type        = string


### PR DESCRIPTION
- Changing instructions to reference usage of trussworks fork of the antivirus function with the correct version number
- Removed the comment about upsidetravel/bucket-anti-virus since it seems like that functionality had already been merged into the bluesentry source.
- .pre-commit-config.yml was still using `git://` instead of `https://`