### PR TITLE
fixing a mix of strings and bools

### DIFF
--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "main_scan" {
       "s3:GetObjectVersion",
       "s3:PutObjectTagging",
       "s3:PutObjectVersionTagging"
-    ],var.av_delete_infected_files ? ["s3:DeleteObject"] : [])
+    ], var.av_delete_infected_files == "True" ? ["s3:DeleteObject"] : [])
 
     resources = formatlist("%s/*", data.aws_s3_bucket.main_scan.*.arn)
   }


### PR DESCRIPTION
## Summary

Attempting to apply this in our infrastructure resulted in the following error:
```
│ Error: Incorrect condition type
│ 
│   on .terraform/modules/s3_anti_virus/anti-virus-scan.tf line 49, in data "aws_iam_policy_document" "main_scan":
│   49:     ],var.av_delete_infected_files ? ["s3:DeleteObject"] : [])
│     ├────────────────
│     │ var.av_delete_infected_files is "False"
│ 
│ The condition expression must be of type bool.
```

This PR fixes this by doing a string comparison against "True" instead of treating `var.av_delete_infected_files` as a boolean