### PR TITLE
deprecate older terraform versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ module "s3_anti_virus" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -34,11 +34,6 @@ Creates the following resources for anti-virus scanning:
 * S3 Event to trigger function on object creation
 * AWS Lambda function to scan S3 object and send alert to slack if any objects are infected and quarantined.
 
-## Terraform Versions
-
-Terraform 0.13 and newer. Pin module version to `~> 3.X`. Submit pull-requests to `main` branch.
-
-Terraform 0.12. Pin module version to `~> 2.X`. Submit pull-requests to `terraform012` branch.
 
 ## Usage
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = ">= 3.0"


### PR DESCRIPTION
## [Deprecate support for ancient terraform versions in our modules](https://trello.com/c/H27opwG6)

- Modified README
- Set expected terraform version to be equal or greater than Terraform version 1.0