### PR TITLE
INFRA-5855 Add missing kms:Decrypt permission to lambda role

### DIFF
--- a/.github/workflows/pr-security.yaml
+++ b/.github/workflows/pr-security.yaml
@@ -1,0 +1,32 @@
+---
+# onemedical/<repo>/.github/workflows/pr-security.yaml
+#
+# This is the workflow for distribution to repositories across the organization.
+# It will call the reusable PR security workflow, and run scans against each PR.
+name: PR Security
+
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches: [main, master]
+
+
+permissions:
+  # Required for workflows in private repositories.
+  contents: read
+
+  # Required for SARIF results upload to GHAS.
+  security-events: write
+  actions: read
+
+
+jobs:
+  # Run the reusable workflow.
+  run-workflow:
+    name: Run Workflow
+    # yamllint disable-line rule:line-length
+    uses: onemedical/github-reusable-workflows/.github/workflows/reusable-pr-security.yaml@main
+    # The detect-secrets tool is used in some repositories, and generates false
+    # positives like the one below. Add comment to ignore.
+    secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -1,0 +1,26 @@
+# onemedical/<repo>/.github/workflows/tag-and-release-terraform-module.yaml
+#
+# This is the workflow for distribution to repositories across the organization.
+# It will call the reusable Tag and Release Terraform Module workflow,
+# which will create a new tag based on a value in version file and create a GitHub release.
+---
+name: 🏷 Tag and Release
+
+
+on:
+  push:
+    paths:
+      - version
+    branches: [main, master]
+
+
+permissions:
+  # Required for workflows in private repositories.
+  contents: write
+
+
+jobs:
+  # Call the reusable workflow.
+  call-workflow:
+    name: Call Workflow
+    uses: onemedical/github-reusable-workflows/.github/workflows/reusable-tag-and-release-terraform-module.yaml@main

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -1,8 +1,4 @@
-# onemedical/<repo>/.github/workflows/tag-and-release-terraform-module.yaml
-#
-# This is the workflow for distribution to repositories across the organization.
-# It will call the reusable Tag and Release Terraform Module workflow,
-# which will create a new tag based on a value in version file and create a GitHub release.
+# Create a new GitHub tag and release based on a value in version file.
 ---
 name: 🏷 Tag and Release
 
@@ -11,16 +7,30 @@ on:
   push:
     paths:
       - version
-    branches: [main, master]
-
-
-permissions:
-  # Required for workflows in private repositories.
-  contents: write
-
+    branches:
+      - main
 
 jobs:
-  # Call the reusable workflow.
-  call-workflow:
-    name: Call Workflow
-    uses: onemedical/github-reusable-workflows/.github/workflows/reusable-tag-and-release-terraform-module.yaml@main
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Check out code
+        uses: actions/checkout@v3
+
+      - name: 🏷 Create a tag
+        id: create-tag
+        uses: butlerlogic/action-autotag@stable
+        with:
+          strategy: regex
+          root: "version"
+          regex_pattern: "(\\d+\\.\\d+\\.\\d+)"
+          tag_prefix: "v"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: 🦄 Create a release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          tag: ${{ steps.create-tag.outputs.tagname }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ module "s3_anti_virus" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 
@@ -110,6 +110,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_activate_s3_event_notification"></a> [activate\_s3\_event\_notification](#input\_activate\_s3\_event\_notification) | true activates the s3 event notification to clamav. default is false | `bool` | `false` | no |
 | <a name="input_av_definition_s3_bucket"></a> [av\_definition\_s3\_bucket](#input\_av\_definition\_s3\_bucket) | Bucket containing antivirus database files. | `string` | n/a | yes |
 | <a name="input_av_definition_s3_prefix"></a> [av\_definition\_s3\_prefix](#input\_av\_definition\_s3\_prefix) | Prefix for antivirus database files. | `string` | `"clamav_defs"` | no |
 | <a name="input_av_delete_infected_files"></a> [av\_delete\_infected\_files](#input\_av\_delete\_infected\_files) | Set it True in order to delete infected values. | `string` | `"False"` | no |
@@ -130,6 +131,7 @@ No modules.
 | <a name="input_name_scan"></a> [name\_scan](#input\_name\_scan) | Name for resources associated with anti-virus scanning | `string` | `"s3-anti-virus-scan"` | no |
 | <a name="input_name_update"></a> [name\_update](#input\_name\_update) | Name for resources associated with anti-virus updating | `string` | `"s3-anti-virus-updates"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | ARN of the boundary policy to attach to IAM roles. | `string` | `null` | no |
+| <a name="input_platform"></a> [platform](#input\_platform) | Instruction set architecture for your Lambda function. Valid values are 'x86\_64' and 'arm64' | `string` | `"arm64"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | <a name="input_timeout_seconds"></a> [timeout\_seconds](#input\_timeout\_seconds) | Lambda timeout, in seconds | `string` | `300` | no |
 

--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -88,6 +88,7 @@ data "aws_iam_policy_document" "main_scan" {
 
       actions = [
         "kms:GenerateDataKey",
+        "kms:Decrypt"
       ]
 
       resources = [

--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -194,6 +194,8 @@ resource "aws_lambda_function" "main_scan" {
     }
   }
 
+  architectures = [var.platform]
+
   tags = merge(
     {
       "Name" = var.name_scan

--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -135,7 +135,7 @@ data "aws_s3_bucket" "main_scan" {
 }
 
 resource "aws_s3_bucket_notification" "main_scan" {
-  count  = length(var.av_scan_buckets)
+  count  = var.activate_s3_event_notification ? length(var.av_scan_buckets) : 0
   bucket = element(data.aws_s3_bucket.main_scan.*.id, count.index)
 
   lambda_function {

--- a/anti-virus-update.tf
+++ b/anti-virus-update.tf
@@ -141,6 +141,8 @@ resource "aws_lambda_function" "main_update" {
     }
   }
 
+  architectures = [var.platform]
+
   tags = merge(
     {
       "Name" = var.name_update

--- a/variables.tf
+++ b/variables.tf
@@ -130,3 +130,9 @@ variable "platform" {
   type        = string
   default     = "arm64"
 }
+
+variable "activate_s3_event_notification" {
+  description = "true activates the s3 event notification to clamav. default is false"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -124,3 +124,9 @@ variable "cloudwatch_kms_arn" {
   type        = string
   default     = ""
 }
+
+variable "platform" {
+  description = "Instruction set architecture for your Lambda function. Valid values are 'x86_64' and 'arm64'"
+  type        = string
+  default     = "arm64"
+}

--- a/version
+++ b/version
@@ -1,3 +1,3 @@
 # Incrementing the version number below will trigger a
 # release tag with that version to be created automatically.
-3.0.2
+3.0.3

--- a/version
+++ b/version
@@ -1,0 +1,3 @@
+# Incrementing the version number below will trigger a
+# release tag with that version to be created automatically.
+3.0.0

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
-    aws = ">= 3.0"
+    aws = ">= 5.0"
   }
 }


### PR DESCRIPTION
[INFRA-5855](https://onemedical.atlassian.net/browse/INFRA-5855)

- Add `kms:Decrypt`

Error message seen:

```text
[ERROR] KMSAccessDeniedException: An error occurred (KMSAccessDenied) when calling the Publish operation: User: arn:aws:sts::193567999519:assumed-role/lambda-alpha-amsterdam-clamav-scan/alpha-amsterdam-clamav-scan is not authorized to perform: kms:Decrypt on resource: arn:aws:kms:us-east-1:193567999519:key/810965d7-2cf3-4704-b084-49d84f88ff1b because no identity-based policy allows the kms:Decrypt action (Service: AWSKMS; Status Code: 400; Error Code: AccessDeniedException; Request ID: b28b1b5a-9032-421c-be02-e0b9558b2509; Proxy: null)
```

This will resolve that error